### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,6 +61,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
 
       - name: Build
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docker-build.yml` file. The change adds an `id` attribute to the `Build` step in the GitHub Actions workflow.

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R64): Added `id: push` to the `Build` step to identify it within the workflow.