### PR TITLE
fix: workflow

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -9,6 +9,9 @@ jobs:
   cleanup:
     runs-on: image-builder
     steps:
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Cleanup
         run: |
           echo "Fetching list of cache key"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,6 +61,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
 
       - name: Build
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -117,6 +117,7 @@ jobs:
 
       - name: Build
         uses: docker/build-push-action@v6
+        id: push
         with:
           context: .
           file: ./dockerfiles/alpine.dockerfile


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to improve the caching and Docker build processes. The most important changes include adding a new action to expose the GitHub runtime and assigning an ID to the Docker build steps.

Improvements to caching:

* [`.github/workflows/cleanup-caches.yml`](diffhunk://#diff-8945a3361778b570d0b11fc891f119ef85ed7959a3f49cac6c914a76626bc36eR12-R14): Added the `crazy-max/ghaction-github-runtime@v3` action to expose the GitHub runtime.

Enhancements to Docker build process:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R64): Assigned an ID (`push`) to the Docker build step to facilitate referencing the build output in subsequent steps. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R64) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R120)