### PR TITLE
fix: update ruleset configuration and improve script logic

### DIFF
--- a/conf/pulledpork.conf
+++ b/conf/pulledpork.conf
@@ -1,5 +1,5 @@
 # Which Snort/Talos rulesets do you want to download (recomended: choose only one)
-community_ruleset = true
+community_ruleset = false
 registered_ruleset = false
 LightSPD_ruleset = false
 

--- a/conf/snort.lua
+++ b/conf/snort.lua
@@ -108,8 +108,8 @@ reputation =
 
     --blocklist = 'blacklist file name with ip lists'
     --allowlist = 'whitelist file name with ip lists'
-    blocklist = BLACK_LIST_PATH .. 'reputation.blocklist',
-    allowlist = WHITE_LIST_PATH .. 'reputation.allowlist',
+    blocklist = BLACK_LIST_PATH .. '/reputation.blocklist',
+    allowlist = WHITE_LIST_PATH .. '/reputation.allowlist',
 }
 
 ---------------------------------------------------------------------------

--- a/dockerfiles/alpine.dockerfile
+++ b/dockerfiles/alpine.dockerfile
@@ -135,7 +135,8 @@ RUN set -eux; \
     /usr/local/etc/snort3/lists ; \
     touch /usr/local/etc/snort3/rules/local.rules \
     /usr/local/etc/snort3/lists/reputation.blocklist \
-    /usr/local/etc/snort3/lists/reputation.whitelist
+    /usr/local/etc/snort3/lists/reputation.allowlist \
+    /usr/local/etc/snort3/rules/pulledpork.rules
 
 COPY --link conf/pulledpork.conf /usr/local/etc/pulledpork/pulledpork.conf
 COPY --link conf/snort_defaults.lua /usr/local/etc/snort/snort_defaults.lua

--- a/dockerfiles/debian.dockerfile
+++ b/dockerfiles/debian.dockerfile
@@ -112,7 +112,8 @@ RUN set -eux; \
     /usr/local/etc/snort3/lists ; \
     touch /usr/local/etc/snort3/rules/local.rules \
     /usr/local/etc/snort3/lists/reputation.blocklist \
-    /usr/local/etc/snort3/lists/reputation.whitelist
+    /usr/local/etc/snort3/lists/reputation.allowlist \
+    /usr/local/etc/snort3/rules/pulledpork.rules
 
 COPY --link conf/pulledpork.conf /usr/local/etc/pulledpork/pulledpork.conf
 COPY --link conf/snort_defaults.lua /usr/local/etc/snort/snort_defaults.lua

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,11 @@
 PULLEDPORK_CONF_FILE="/usr/local/etc/pulledpork/pulledpork.conf"
 PULLEDPORT_TEMP_FILE="/tmp/pulledpork.conf"
 
+# Define default ruleset variables
+community_ruleset=false
+registered_ruleset=false
+lightspd_ruleset=false
+
 # copy pulledpork.conf to temp file
 cp "$PULLEDPORK_CONF_FILE" "$PULLEDPORT_TEMP_FILE"
 
@@ -16,21 +21,10 @@ if [ ! -f /usr/local/etc/snort3/rules/local.rules ]; then
     touch /usr/local/etc/snort3/rules/local.rules
 fi
 
-# check if env variable SNORT_OINKCODE is set
-if [ -z "$SNORT_OINKCODE" ]; then
-    echo "SNORT_OINKCODE is not set"
-    exit 1
-fi
-
 # check if env variable NETWORK_INTERFACE is set correctly
 if [ -z "$NETWORK_INTERFACE" ]; then
     echo "NETWORK_INTERFACE is not set"
     exit 1
-fi
-
-# check if env variable DOWNLOAD_RULES is set
-if [ -z "$DOWNLOAD_RULES" ]; then
-    DOWNLOAD_RULES=false
 fi
 
 # check if env variable SNORT_COMPRESSED_RULES_FILE_PATH is set
@@ -38,19 +32,32 @@ if [ -z "$SNORT_COMPRESSED_RULES_FILE_PATH" ]; then
     SNORT_COMPRESSED_RULES_FILE_PATH=""
 fi
 
-# check if community_ruleset is set
-if [ -z "$COMMUNITY_RULESET" ]; then
-    COMMUNITY_RULESET=false
+# check if env variable RULESET is set
+if [ -z "$RULESET" ]; then
+    RULESET="community"
 fi
 
-# check if registered_ruleset is set
-if [ -z "$REGISTERED_RULESET" ]; then
-    REGISTERED_RULESET=false
-fi
-
-# check if LightSPD_ruleset is set
-if [ -z "$LIGHTSPD_RULESET" ]; then
-    LIGHTSPD_RULESET=false
+# check which ruleset is enabled from ruleset variables
+# ruleset valid values are: community, registered, lightspd
+if [ -n "$RULESET" ]; then
+    case "$RULESET" in
+        "community")
+            community_ruleset=true
+            echo "=> Using Community Ruleset"
+            ;;
+        "registered")
+            registered_ruleset=true
+            echo "=> Using Registered Ruleset"
+            ;;
+        "lightspd")
+            lightspd_ruleset=true
+            echo "=> Using LightSPD Ruleset"
+            ;;
+        *)
+            echo "RULESET must be one of: community, registered, lightspd. Default is community"
+            exit 1
+            ;;
+    esac
 fi
 
 # check if snort_blocklist is set
@@ -86,33 +93,28 @@ sed -i "s/ips_policy = .*/ips_policy = $IPS_POLICY/g" "$PULLEDPORT_TEMP_FILE"
 if [ -n "$BLOCKLIST_URLS" ]; then
     sed -i "s/#blocklist_urls = .*/blocklist_urls = $BLOCKLIST_URLS/g" "$PULLEDPORT_TEMP_FILE"
 else
-    sed -i "s/blocklist_urls = .*/#blocklist_urls = http://a.b.com/list.list/g" "$PULLEDPORT_TEMP_FILE"
+    sed -i "s/blocklist_urls = .*/#blocklist_urls = http:\/\/a.b.com\/list.list/g" "$PULLEDPORT_TEMP_FILE"
 fi
 
 # replace community_ruleset in pulledpork.conf file with the one provided
-sed -i "s/community_rules = .*/community_rules = $COMMUNITY_RULESET/g" "$PULLEDPORT_TEMP_FILE"
+sed -i "s/community_ruleset = .*/community_ruleset = $community_ruleset/g" "$PULLEDPORT_TEMP_FILE"
 
 # replace registered_ruleset in pulledpork.conf file with the one provided
-sed -i "s/registered_rules = .*/registered_rules = $REGISTERED_RULESET/g" "$PULLEDPORT_TEMP_FILE"
+sed -i "s/registered_ruleset = .*/registered_ruleset = $registered_ruleset/g" "$PULLEDPORT_TEMP_FILE"
 
-# replace LightSPD_ruleset in pulledpork.conf file with the one provided
-sed -i "s/LightSPD_rules = .*/LightSPD_rules = $LIGHTSPD_RULESET/g" "$PULLEDPORT_TEMP_FILE"
+# replace lightspd_ruleset in pulledpork.conf file with the one provided
+sed -i "s/LightSPD_ruleset = .*/LightSPD_ruleset = $lightspd_ruleset/g" "$PULLEDPORT_TEMP_FILE"
 
-# replace oinkcode in pulledpork.conf file with the one provided
-sed -i "s/oinkcode = .*/oinkcode = $SNORT_OINKCODE/g" "$PULLEDPORT_TEMP_FILE"
+# replace oinkcode in pulledpork.conf file with the one provided if set
+if [ -n "$SNORT_OINKCODE" ]; then
+    sed -i "s/oinkcode = .*/oinkcode = $SNORT_OINKCODE/g" "$PULLEDPORT_TEMP_FILE"
+fi
 
 # replace snort_blocklist in pulledpork.conf file with the one provided
 sed -i "s/snort_blocklist = .*/snort_blocklist = $SNORT_BLOCKLIST/g" "$PULLEDPORT_TEMP_FILE"
 
 # replace et_blocklist in pulledpork.conf file with the one provided
 sed -i "s/et_blocklist = .*/et_blocklist = $ET_BLOCKLIST/g" "$PULLEDPORT_TEMP_FILE"
-
-# run pulledpork if DOWNLOAD_RULES is set to true
-if [ "$DOWNLOAD_RULES" = true ]; then
-    echo "Downloading Snort Rules..."
-
-    pulledpork.py -c "$PULLEDPORT_TEMP_FILE" || exit $?
-fi
 
 # if SNORT_BLOCKLIST or ET_BLOCKLIST are set true or BLOCKLIST_URLS is not empty, then uncomment blocklist_path
 if [ "$SNORT_BLOCKLIST" = true ] || [ "$ET_BLOCKLIST" = true ] || [ -n "$BLOCKLIST_URLS" ]; then
@@ -129,14 +131,24 @@ if [ -n "$SNORT_COMPRESSED_RULES_FILE_PATH" ]; then
         exit 1
     fi
 
-    echo "Extracting Snort Rules..."
+    echo "=> Extracting Snort Rules..."
 
     pulledpork.py -f "$SNORT_COMPRESSED_RULES_FILE_PATH" -c "$PULLEDPORT_TEMP_FILE" || exit $?
+else
+    # Check if SNORT_OINKCODE is set and not equal to "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" and RULESET is not community
+    if [ -z "$SNORT_OINKCODE" ] && [ "$RULESET" != "community" ]; then
+        echo "SNORT_OINKCODE is not set, you can get it from your registered user at https://snort.org"
+        exit 1
+    fi
+
+    echo "=> Downloading Snort Rules..."
+
+    pulledpork.py -c "$PULLEDPORT_TEMP_FILE" || exit $?
 fi
 
 # remove temp file
 rm -f "$PULLEDPORT_TEMP_FILE"
 
-echo "Starting Snort..."
+echo "=> Starting Snort..."
 
-/usr/local/bin/snort -c /usr/local/etc/snort/snort.lua -y -s 65535 -m 0x1b -k none -l /var/log/snort -u snort -g snort --plugin-path=/usr/local/etc/snort3/so_rules/ -i "$NETWORK_INTERFACE"
+exec /usr/local/bin/snort -c /usr/local/etc/snort/snort.lua -y -s 65535 -m 0x1b -k none -l /var/log/snort -u snort -g snort --plugin-path=/usr/local/etc/snort3/so_rules/ -i "$NETWORK_INTERFACE"


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and initialization scripts for Snort. The most important changes include updates to the configuration files, Dockerfiles, and the `start.sh` script to enhance flexibility and correctness in setting up Snort rulesets and blocklists.

Configuration file updates:

* [`conf/pulledpork.conf`](diffhunk://#diff-adadc9dff40414bb09d9e0b0c8497be611e5c2e2c369f6d501b3003de52de694L2-R2): Changed the default value of `community_ruleset` from `true` to `false`.
* [`conf/snort.lua`](diffhunk://#diff-41bb1ecf24f9433c2e0e6ccc5c2918508cdd95bf96dd2d951b2911ebfca9b2dcL111-R112): Corrected the paths for `blocklist` and `allowlist` by adding a leading slash.

Dockerfile updates:

* [`dockerfiles/alpine.dockerfile`](diffhunk://#diff-acd8133e3c7ea6fb861795ef2362b246a7ccc66aed32838936b846b7bb172ac5L138-R139): Added `pulledpork.rules` to the list of files to be touched and corrected the name of the `reputation.allowlist` file.
* [`dockerfiles/debian.dockerfile`](diffhunk://#diff-26f986ee4fe686f42d2fef55f19014fc348f514f0c82a9a916d28d66dc10fb70L115-R116): Made the same changes as in the Alpine Dockerfile.

Script updates:

* [`start.sh`](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5R6-R10): Introduced default ruleset variables and refactored the script to use a single `RULESET` environment variable to determine which ruleset to enable. [[1]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5R6-R10) [[2]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5L19-R60)
* [`start.sh`](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5L89-L116): Improved the handling of the `pulledpork.conf` file by replacing the ruleset variables and ensuring the `oinkcode` is only set if provided.
* [`start.sh`](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5L132-R154): Added logic to check for `SNORT_OINKCODE` when the `RULESET` is not `community` and refactored the script to download or extract Snort rules as needed.