### PR TITLE
ci: align docker-bake.hcl registry and simplify to single-arch

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: image-builder
     steps:
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -5,9 +5,14 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   cleanup:
     runs-on: image-builder
+    if: github.event.pull_request.merged == true
     steps:
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,12 +3,12 @@ name: Build Snort3 Docker Image
 on:
   push:
     branches:
-      - v2.0
+      - main
     tags:
       - "v*"
   pull_request:
     branches:
-      - v2.0 # Optional: Run the workflow on PRs target
+      - main
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,14 +48,6 @@ jobs:
             prefix=
             suffix=-debian
 
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v3
-      #   with:
-      #     platforms: linux/amd64,linux/arm64
-
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
-
       - name: Expose GitHub Runtime
         if: github.event_name != 'pull_request'
         uses: crazy-max/ghaction-github-runtime@v3
@@ -106,14 +98,6 @@ jobs:
             latest=false
             prefix=
             suffix=-alpine
-
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v3
-      #   with:
-      #     platforms: linux/amd64,linux/arm64
-
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
 
       - name: Build
         uses: docker/build-push-action@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Build Commands
+
+```bash
+# Local build (debian)
+make build
+
+# Local build (alpine)
+make build-alpine
+
+# Multi-arch push to registry (uses docker-bake.hcl)
+make build-push
+```
+
+## CI Notes
+
+- Workflows trigger on `v2.0` branch, not `main`
+- CI uses a custom runner `image-builder` — not `ubuntu-latest`
+- Cleanup workflow only runs on PR close, uses custom token env vars
+
+## Linting
+
+- `.hadolint.yaml` ignores: `DL3003`, `DL3008`, `DL3018`, `SC2046`

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -19,7 +19,7 @@ variable "hyperscan_version" {
 }
 
 variable "image_repo_host" {
-    default = "mfscy"
+    default = "ghcr.io/mata-elang-stable/snort3-docker-image"
 }
 
 variable "image_tag" {
@@ -51,11 +51,6 @@ target "docker-metadata-action" {}
 target "virtual-platforms" {
   platforms = [
     "linux/amd64",
-    // "linux/386",
-    "linux/arm64",
-    // "linux/arm/v7",
-    // "linux/ppc64le",
-    // "linux/s390x",
   ]
 }
 


### PR DESCRIPTION
## Changes
### .github/workflows/docker-build.yml
- Change CI triggers from `v2.0` to `main` branch
- Remove commented-out QEMU and Docker Buildx setup steps from both jobs
### .github/workflows/cleanup-caches.yml
- Change `runs-on` from `ubuntu-latest` to `image-builder` for consistent cache access
- Add `if: github.event.pull_request.merged == true` to only run on PR merge, not close
- Add explicit `permissions` block
### docker-bake.hcl
- Update `image_repo_host` from `mfscy` to `ghcr.io/mata-elang-stable/snort3-docker-image`
- Remove `linux/arm64` and other unused architectures from `virtual-platforms`